### PR TITLE
WIP: Wirepatternize

### DIFF
--- a/components/Split.coffee
+++ b/components/Split.coffee
@@ -1,28 +1,25 @@
 noflo = require 'noflo'
 
-class Split extends noflo.Component
-  description: 'This component receives data on a single input port and
+exports.getComponent = ->
+  c = new noflo.Component
+  c.icon = 'expand'
+  c.description = 'This component receives data on a single input port and
     sends the same data out to all connected output ports'
-  icon: 'expand'
 
-  constructor: ->
-    @inPorts = new noflo.InPorts
-      in:
-        datatype: 'all'
-        description: 'Packet to be forwarded'
-    @outPorts = new noflo.OutPorts
-      out:
-        datatype: 'all'
+  c.inPorts.add 'in',
+    datatype: 'all'
+    description: 'Packet to be forwarded'
 
-    @inPorts.in.on 'connect', =>
-      @outPorts.out.connect()
-    @inPorts.in.on 'begingroup', (group) =>
-      @outPorts.out.beginGroup group
-    @inPorts.in.on 'data', (data) =>
-      @outPorts.out.send data
-    @inPorts.in.on 'endgroup', =>
-      @outPorts.out.endGroup()
-    @inPorts.in.on 'disconnect', =>
-      @outPorts.out.disconnect()
+  c.outPorts.add 'out',
+    datatype: 'all'
 
-exports.getComponent = -> new Split
+  noflo.helpers.WirePattern c,
+    in: 'in'
+    out: 'out'
+    forwardGroups: true
+    async: true
+  , (data, groups, out, callback) ->
+    out.send data
+    do callback
+
+  c

--- a/spec/Split.coffee
+++ b/spec/Split.coffee
@@ -1,0 +1,93 @@
+noflo = require 'noflo'
+
+unless noflo.isBrowser()
+  chai = require 'chai' unless chai
+  Split = require '../components/Split.coffee'
+else
+  Split = require 'noflo-core/components/Split.js'
+
+describe 'Split component', ->
+  c = null
+  ins = null
+  out = null
+
+  beforeEach ->
+    c = Split.getComponent()
+    ins = noflo.internalSocket.createSocket()
+    out = noflo.internalSocket.createSocket()
+    c.inPorts.in.attach ins
+    c.outPorts.out.attach out
+
+  describe 'when instantiated', ->
+    it 'should have an input port', ->
+      chai.expect(c.inPorts.in).to.be.an 'object'
+
+    it 'should have an output port', ->
+      chai.expect(c.outPorts.out).to.be.an 'object'
+
+  describe 'when sending no packet, only groups', ->
+    it 'should forward no packet', (done) ->
+      @timeout 500
+      setTimeout done, 100
+      ins.beginGroup 'foo'
+      ins.endGroup()
+
+  describe 'when sending only one packet', ->
+    it 'should forward the packet', (done) ->
+      out.on 'data', (data) ->
+        chai.expect(data).to.equal 'foo'
+        done()
+      ins.send 'foo'
+    it 'should forward groups', (done) ->
+      groups = []
+      out.on 'begingroup', (group) ->
+        groups.push group
+      out.on 'endgroup', ->
+        groups.pop()
+      out.on 'data', (data) ->
+        chai.expect(data).to.equal 'foo'
+        chai.expect(groups[0]).to.equal 'bar'
+        done()
+      ins.beginGroup 'bar'
+      ins.send 'foo'
+      ins.endGroup()
+
+  describe 'when sending many packets', ->
+    it 'should forward all packets', (done) ->
+      ids = ['foo', 'bar', 'baz']
+      packets = []
+      out.on 'data', (data) ->
+        packets.push data
+        if packets.length > 2
+          chai.expect(packets.length).to.deep.equal 3
+          for id in ids
+            chai.expect(packets).to.include id
+          packets = []
+          done()
+      for id in ids
+        ins.send id
+    it 'should forward the right groups', (done) ->
+      ids = ['foo', 'bar', 'baz']
+      packets = []
+      groups = []
+      out.on 'begingroup', (group) ->
+        groups.push group
+      out.on 'endgroup', ->
+        groups.pop()
+      out.on 'data', (data) ->
+        packets.push
+          data: data
+          groups: groups.slice 0
+        if packets.length > 2
+          chai.expect(packets.length).to.deep.equal 3
+          for id in ids
+            allData = (packet.data for packet in packets)
+            idGroups = (packet.groups for packet in packets when packet.data is id)
+            chai.expect(allData).to.include id
+            chai.expect(idGroups[0]).to.deep.equal [ "group-of-#{id}" ]
+          packets = []
+          done()
+      for id in ids
+        ins.beginGroup "group-of-#{id}"
+        ins.send id
+        ins.endGroup()


### PR DESCRIPTION
@bergie how can we left `Drop` without an outport? WirePattern seems to expect at least the default 'out' outport.

How can we send packets only on disconnect event on `Merge`?